### PR TITLE
Small fixes for Python 3.9 and requesting all records instead of only 100

### DIFF
--- a/weclapp/api.py
+++ b/weclapp/api.py
@@ -97,8 +97,8 @@ class WeclappAPI(object):
             kwargs = {}
             if len(cts) > 1 and cts[1].startswith('charset'):
                 enc = cts[1].split("=")
-                if len(enc) > 1:
-                    kwargs['encoding'] = enc[1]
+                #if len(enc) > 1:
+                #    kwargs['encoding'] = enc[1]
 
             try:
                 data = json.loads(data, **kwargs)

--- a/weclapp/models/base.py
+++ b/weclapp/models/base.py
@@ -59,7 +59,7 @@ class WeclappBaseModel(object):
 
 
     @classmethod
-    def load(cls, sort=None, pageSize=100, serializeNulls=True):
+    def load(cls, sort=None, pageSize=-1, serializeNulls=True):
         """
         Fetches the data from the public API
 

--- a/weclapp/models/project.py
+++ b/weclapp/models/project.py
@@ -49,7 +49,7 @@ class WeclappProject(WeclappBaseModel):
         print(msg.format(indent, self.projectNumber, self.name, self.id, billable))
 
     @classmethod
-    def load(cls, tasks=True, time_records=100, **kwargs):
+    def load(cls, tasks=True, time_records=-1, **kwargs):
         """
         Loads projects
 

--- a/weclapp/models/timeRecord.py
+++ b/weclapp/models/timeRecord.py
@@ -47,6 +47,12 @@ class WeclappTimeRecord(WeclappBaseModel):
         for field in ['billable', 'projectId', 'projectTaskId', 'durationSeconds' ]:
             ret[field] = getattr(self, field)
 
+        # Necessary fix because variable is set to false somewhere
+        ret['billable'] = bool(True)
+
+        # Necessary fix since weclapp needs this vaule to be != 0 or billable will be set to false
+        ret['billableDurationSeconds'] = ret['durationSeconds']
+
         ret['startDate'] = int(self.startDate.timestamp() * 1000)
 
         if isinstance(self.description, str) and self.description.strip() != '':
@@ -89,6 +95,9 @@ class WeclappTimeRecord(WeclappBaseModel):
         """
 
         body = json.dumps(self.dict_for_upload())
+
+        # Uncomment the following line if you want to see the plain request being sent
+        #print("DEBUG Request body: %s" % body)
 
         try:
             res = self.__api__.call(self.__fetch_command__, 'POST', body=body, expected_status_code=201)


### PR DESCRIPTION
The changes in `api.py` for Python 3.9 fixes this error:
`Something went wrong: Unable to get JSON response: JSONDecoder.__init__() got an unexpected keyword argument 'encoding'`

And requesting all records instead of only 100 fixes this error:
`AttributeError: 'NoneType' object has no attribute 'add_time_record'`

Both happened while executing `weclapp-cli -d projects`